### PR TITLE
added mu-editor to requirements

### DIFF
--- a/wordprocessor/requirements.txt
+++ b/wordprocessor/requirements.txt
@@ -1,1 +1,2 @@
 PyQt5>=5.6
+mu-editor


### PR DESCRIPTION
I needed it to run this example, otherwise I got error:

ImportError: /usr/local/lib/python3.5/dist-packages/PyQt5/QtGui.so: undefined symbol: PySlice_AdjustIndices